### PR TITLE
Images should be served over the cdn when using npm

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -61,7 +61,7 @@ const cssLoader = {
     },
 };
 
-const imageFileLoader = {
+let imageFileLoader = {
     loader: 'file-loader',
     options: {
         outputPath: 'images/',
@@ -112,6 +112,15 @@ const config = (env) => {
                 emitFile: false,
                 name: '[name].[ext]',
                 publicPath: 'https://cdn.jsdelivr.net/gh/HandsFree/accessabar/src/fonts/',
+            },
+        };
+
+        imageFileLoader = {
+            loader: 'file-loader',
+            options: {
+                emitFile: false,
+                name: '[name].[ext]',
+                publicPath: 'https://cdn.jsdelivr.net/gh/HandsFree/accessabar/src/images/',
             },
         };
     }


### PR DESCRIPTION
Quick fix to stop webpack emiting the logo image and add cdn link when using npm